### PR TITLE
add encoding for fix #46

### DIFF
--- a/GTStoWIS2/__init__.py
+++ b/GTStoWIS2/__init__.py
@@ -39,7 +39,7 @@ class GTStoWIS2():
 
         for t in [ 'A', 'B', 'C1', 'C2', 'C3', 'C6', 'C6', 'C7', 'CCCC', 'GISC', 'D1', 'D2' ]:
             f = self.tableDir + '/Table%s.json' % t
-            with open( f, 'r' ) as m:
+            with open( f, 'r',encoding="UTF-8" ) as m:
                 if self.debug: print( 'reading %s' % f )
                 exec( "self.table"+t+"=json.load(m)" )
             if self.dump:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 def read(*parts):
     # intentionally *not* adding an encoding option to open, See:
     #   https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
-    return codecs.open(os.path.join(here, *parts), 'r').read()
+    return codecs.open(os.path.join(here, *parts), 'r', encoding="UTF-8").read()
 
 packages=find_packages()
 print("packages = %s" % packages)

--- a/test.py
+++ b/test.py
@@ -7,7 +7,10 @@ Place test AHL's here to see how they are interpreted.
 print ( "%s" % __file__ )
 
 import GTStoWIS2
+import sys
+import io
 
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
 topic_builder=GTStoWIS2.GTStoWIS2(debug=False,dump_tables=False)
 
 with open( 'AHL_examples.txt', 'r' ) as headers:


### PR DESCRIPTION
This fix is for issue #46.

**problem**

In the following environments, the installation may fail
because the getfilesystemencoding of python is "ascii".

- locale is POSIX
- python <= 3.6

**solution**

Opening file with python, I specify the encoding(=UTF-8).
Since test.py outputs non-ascii characters to stdout, I specify the stdout's encoding too.
