### PR TITLE
Fix including JSON tables in distributed library: Use package_data over include_package_data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,10 @@ INSTALLATION
 The module is a python package. 
 Installing::
 
+   pip3 install git+https://github.com/wmo-im/GTStoWIS2.git
+
+Or if you wish to have the package editable and available locally::
+
    git clone https://github.com/wmo-im/GTStoWIS2.git
    cd GTStoWIS2
    pip3 install -e .

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,9 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     packages = [ 'GTStoWIS2' ],
-    include_package_data=True,
+    package_data={
+        "GTStoWIS2": ["*.json"], # includes all Table json files in dist
+    }
 )
     
     


### PR DESCRIPTION
Building the source or binary distributions of this python library produces a package without any of the table files present. `include_package_data=True` is insufficient and seemed to not pick up the files.

Indeed, this StackOverflow entry seems to detail the woe: https://stackoverflow.com/questions/7522250/how-to-include-package-data-with-setuptools-distutils

By using `package_data` not only does it now seem to work on both source and binary distributions (ie the files get copied when running `python setup.py sdist bdist`) but there's also finer-grained control on what files to include in the final package/library.

This is relevant/important as I, and others, may rely upon using `pip3 install git+https://github.com/wmo-im/GTStoWIS2.git#main` instead of cloning the repo locally and installing from that directory as indicated in your README.rst instructions.

* * *

## Bug Report Approach 1
### Steps to reproduce

```
pip3 install git+https://github.com/wmo-im/GTStoWIS2.git#main
python3
```

```python3
import GTStoWIS2
topic_mapper = GTStoWIS2.GTStoWIS2()
```

### Expected

It works, with an instance of the class

### Actual

```
>>> GTStoWIS2.GTStoWIS2()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/justin/.pyenv/versions/3.9.5/lib/python3.9/site-packages/GTStoWIS2/__init__.py", line 97, in __init__
    self._readTables()
  File "/Users/justin/.pyenv/versions/3.9.5/lib/python3.9/site-packages/GTStoWIS2/__init__.py", line 42, in _readTables
    with open( f, 'r',encoding="UTF-8" ) as m:
FileNotFoundError: [Errno 2] No such file or directory: '/Users/justin/.pyenv/versions/3.9.5/lib/python3.9/site-packages/GTStoWIS2/TableA.json'
```

## Bug Report Approach 2
### Steps to reproduce

```
git clone https://github.com/wmo-im/GTStoWIS2.git
cd GTStoWIS2
python3 setup.py sdist bdist
cd dist
tar xvfz GTStoWIS2-0.0.2.tar.gz
ls GTStoWIS2-0.0.2/GTStoWIS2
```

Observe the resulting list of files from inside the package/library.

### Expected

The `__init__.py` file along with its siblings `Table*.json` files

### Actual

Just the `__init__.py` file alone.
