### PR TITLE
Adding "type" and "geometry" to please GeoJSON #81

### DIFF
--- a/message_format/message-schema.json
+++ b/message_format/message-schema.json
@@ -80,6 +80,20 @@
       ],
       "pattern": "^(.*)$"
     },
+    "type": {
+      "$id": "#/properties/type",
+      "type": "string",
+      "title": "Fixed value",
+      "description": "Type is needed for compatibility with GeoJSON, it is set to a fixed value",
+      "const": "Feature",
+      "examples": [
+        "Feature"
+      ]
+    },
+    "geometry": {
+      "$ref": "https://geojson.org/schema/Geometry.json",
+      "description": "Geometry is needed for compatibility with GeoJSON, it is set to a fixed value",
+    },
     "size": {
       "$id": "#/properties/size",
       "type": "integer",


### PR DESCRIPTION
So far they are not required. Adding "type": "Feature" is not painful. The geometry is a problem. I mean, that the publisher of the notification may need to do non-trivial processing to deduce the geometry (and may fail if the data has some unknown format).